### PR TITLE
fix: statu bar has a small over the header

### DIFF
--- a/app/config/DrawerRoute.js
+++ b/app/config/DrawerRoute.js
@@ -12,7 +12,7 @@ const styles = EStyleSheet.create({
   header: {
     backgroundColor: '$primary',
     justifyContent: 'center',
-    marginTop: Platform.OS === 'ios' ? 0 : Constants.statusBarHeight
+    paddingTop: Platform.OS === 'ios' ? 0 : Constants.statusBarHeight
   },
   hamburgerIcon: {
     color: 'white',

--- a/app/config/DrawerRoute.js
+++ b/app/config/DrawerRoute.js
@@ -1,4 +1,6 @@
 import React from 'react'
+import { Platform } from 'react-native'
+import { Constants } from 'expo'
 import { StackNavigator, DrawerNavigator } from 'react-navigation'
 import { Icon } from 'native-base'
 import HomeScreen from '../screens/Home'
@@ -14,6 +16,9 @@ const styles = EStyleSheet.create({
   hamburgerIcon: {
     color: 'white',
     paddingLeft: 10
+  },
+  customAndroidHeader: {
+    marginTop: Platform.OS === 'ios' ? 0 : Constants.statusBarHeight
   }
 })
 

--- a/app/config/DrawerRoute.js
+++ b/app/config/DrawerRoute.js
@@ -11,14 +11,12 @@ import EStyleSheet from 'react-native-extended-stylesheet'
 const styles = EStyleSheet.create({
   header: {
     backgroundColor: '$primary',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    marginTop: Platform.OS === 'ios' ? 0 : Constants.statusBarHeight
   },
   hamburgerIcon: {
     color: 'white',
     paddingLeft: 10
-  },
-  customAndroidHeader: {
-    marginTop: Platform.OS === 'ios' ? 0 : Constants.statusBarHeight
   }
 })
 


### PR DESCRIPTION
As @JesseRWeigel suggestion with the link https://github.com/react-navigation/react-navigation/issues/1168 it look like it fix the problem. I did some test in a few divice Iphone simulator, Blue R1 HD(android 6.0), Samsumg Galaxy Tab A(Android 5.1.1)  and everything looks good.

Note: please test in other device to see if the fix work. 

Thanks you

closes #13 